### PR TITLE
Add hours and minutes to export file name

### DIFF
--- a/lib/settings/settings_export_screen.dart
+++ b/lib/settings/settings_export_screen.dart
@@ -129,7 +129,7 @@ class _SettingsExportScreenState extends State<SettingsExportScreen> {
 
                 var exportData = jsonEncode(data.toJson());
 
-                var dateFormat = DateFormat('yyyy-MM-dd');
+                var dateFormat = DateFormat('yyyy-MM-dd-hhmm');
                 var fileName = 'quacker-${dateFormat.format(DateTime.now())}.json';
 
                 // This platform can support the directory picker, so display it


### PR DESCRIPTION
Adding hours and minutes to the file name used for export will allow for easier management for multiple exports in a day