### PR TITLE
make sure that the built version is always aligned with the pushed git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,15 @@ jobs:
         with:
           flutter-version: '3.10.2'
 
+      - name: Set env
+        run: |
+          APP_VERSION=$(echo ${{github.ref_name}} | sed 's/v//g')
+          echo "APPLICATION_VERSION=$APP_VERSION" >> $GITHUB_ENV
+          APP_BUILD_BASE=300000000
+          COMMIT_NUMBER=$(git rev-list HEAD --count)
+          APP_BUILD_NUMBER=$((APP_BUILD_BASE+COMMIT_NUMBER))
+          echo "APPLICATION_BUILD_NUMBER=$APP_BUILD_NUMBER" >> $GITHUB_ENV
+
       - name: Build APKs
         run: |
           flutter config --no-analytics
@@ -41,11 +50,11 @@ jobs:
           mkdir -pv build/app/outputs/release
 
           # Build our big boy APK, and move it into the release APKs folder
-          flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons
+          flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --build-name=${{env.APPLICATION_VERSION}} --build-number=${{env.APPLICATION_BUILD_NUMBER}}
           mv build/app/outputs/apk/release/*.apk build/app/outputs/release
 
           # Build our ABI-specific APKs and move them into the release APKs folder
-          flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --split-per-abi --target-platform=android-x64,android-arm,android-arm64
+          flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --split-per-abi --target-platform=android-x64,android-arm,android-arm64 --build-name=${{env.APPLICATION_VERSION}} --build-number=${{env.APPLICATION_BUILD_NUMBER}}
           mv build/app/outputs/apk/release/*.apk build/app/outputs/release
         env:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}


### PR DESCRIPTION
This is to fix the bug #56.

This will build a release with version equal to the pushed git tag (minus the prefixed v).

The generated build number is inspired by the release.sh file in root folder.
