### PR TITLE
fix release workflow with condition.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           flutter-version: '3.10.2'
 
       - name: Set env
+        if: github.event_name == 'push'
         run: |
           APP_VERSION=$(echo ${{github.ref_name}} | sed 's/v//g')
           echo "APPLICATION_VERSION=$APP_VERSION" >> $GITHUB_ENV
@@ -50,11 +51,19 @@ jobs:
           mkdir -pv build/app/outputs/release
 
           # Build our big boy APK, and move it into the release APKs folder
-          flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --build-name=${{env.APPLICATION_VERSION}} --build-number=${{env.APPLICATION_BUILD_NUMBER}}
+          if [[ ${{github.event_name}} == 'push' ]]; then
+            flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --build-name=${{env.APPLICATION_VERSION}} --build-number=${{env.APPLICATION_BUILD_NUMBER}}
+          else
+            flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons
+          fi
           mv build/app/outputs/apk/release/*.apk build/app/outputs/release
 
           # Build our ABI-specific APKs and move them into the release APKs folder
-          flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --split-per-abi --target-platform=android-x64,android-arm,android-arm64 --build-name=${{env.APPLICATION_VERSION}} --build-number=${{env.APPLICATION_BUILD_NUMBER}}
+          if [[ ${{github.event_name}} == 'push' ]]; then
+            flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --split-per-abi --target-platform=android-x64,android-arm,android-arm64 --build-name=${{env.APPLICATION_VERSION}} --build-number=${{env.APPLICATION_BUILD_NUMBER}}
+          else
+            flutter build apk --dart-define=app.flavor=github --release --no-tree-shake-icons --split-per-abi --target-platform=android-x64,android-arm,android-arm64
+          fi
           mv build/app/outputs/apk/release/*.apk build/app/outputs/release
         env:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}


### PR DESCRIPTION
This is in relation with bug #56 and the following PR #57.

This fixes the case when release.yml is run manually.
In that case the version will be the one from pubspec.yaml.

But the better approach is still to push a git tag instead of running manually for a release, because then the git tags are perfectly aligned with the release artifacts.
