### PR TITLE
fix to allow storage permission for Android 11+.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <!-- Required for importing and exporting on older versions of Android (<=10) -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Permission for the Android 11 and above -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 
     <!-- Required for importing from qr code -->
     <uses-permission android:name="android.permission.CAMERA" android:required="false"/>

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -259,7 +259,9 @@ class DownloadTypeSettingState extends State<DownloadTypeSetting> {
         if (PrefService.of(context).get(optionDownloadType) == optionDownloadTypeDirectory)
           PrefButton(
             onTap: () async {
-              var storagePermission = await Permission.storage.request();
+              DeviceInfoPlugin plugin = DeviceInfoPlugin();
+              AndroidDeviceInfo android = await plugin.androidInfo;
+              var storagePermission = android.version.sdkInt < 30 ? await Permission.storage.request() : await Permission.manageExternalStorage.request();
               if (storagePermission.isGranted) {
                 String? directoryPath = await FilePicker.platform.getDirectoryPath();
                 if (directoryPath == null) {

--- a/lib/utils/downloads.dart
+++ b/lib/utils/downloads.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_file_dialog/flutter_file_dialog.dart';
 
@@ -19,7 +20,9 @@ Future<void> downloadUriToPickedFile(BuildContext context, Uri uri, String fileN
     onStart();
     var responseTask = downloadFile(context, uri);
 
-    var storagePermission = await Permission.storage.request();
+    DeviceInfoPlugin plugin = DeviceInfoPlugin();
+    AndroidDeviceInfo android = await plugin.androidInfo;
+    var storagePermission = android.version.sdkInt < 30 ? await Permission.storage.request() : await Permission.manageExternalStorage.request();
 
     var response = await responseTask;
     if (response == null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -761,10 +761,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "33c6a1253d1f95fd06fa74b65b7ba907ae9811f9d5c1d3150e51417d04b8d6a8"
+      sha256: "1b6b3e73f0bcbc856548bbdfb1c33084a401c4f143e220629a9055233d76c331"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.3.0"
   permission_handler_android:
     dependency: transitive
     description:
@@ -777,18 +777,18 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: ee96ac32f5a8e6f80756e25b25b9f8e535816c8e6665a96b6d70681f8c4f7e85
+      sha256: "08dcb6ce628ac0b257e429944b4c652c2a4e6af725bdf12b498daa2c6b2b1edb"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.8"
+    version: "9.1.0"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: "68abbc472002b5e6dfce47fe9898c6b7d8328d58b5d2524f75e277c07a97eb84"
+      sha256: de20a5c3269229c1ae2e5a6b822f6cb59578b23e8255c93fbeebfc82116e6b11
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.10.0"
   permission_handler_windows:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   ffcache: ^1.1.0
   flex_color_scheme: ^7.1.2
   flutter_cache: ^0.1.0
-  file_picker: ^5.2.3
+  file_picker: ^5.3.2
   flutter_colorpicker: ^1.0.3
   flutter_file_dialog: ^3.0.1
   flutter_iconpicker_plus: ^3.2.3
@@ -64,7 +64,7 @@ dependencies:
   barcode_scan2: ^4.2.4
   path: ^1.8.2
   path_provider: ^2.0.11
-  permission_handler: ^10.2.0
+  permission_handler: ^10.3.0
   pref: ^2.7.0
   provider: ^6.0.4
   quiver: ^3.1.0


### PR DESCRIPTION
This is a follow up of the issue #67 in the case of devices with Android 11+.

Tis is to allow storage permission to download automatically to directory for devices with Android 11+.
