### PR TITLE
Implemented a way to get a valid x-client-transaction-id header for requests

### DIFF
--- a/lib/client/accounts.dart
+++ b/lib/client/accounts.dart
@@ -1,0 +1,6 @@
+import 'package:quacker/database/repository.dart';
+
+Future<List<Map<String, Object?>>> getAccounts() async {
+  var database = await Repository.readOnly();
+  return database.query(tableAccounts);
+}

--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -7,6 +7,7 @@ import 'package:ffcache/ffcache.dart';
 import 'package:quacker/catcher/exceptions.dart';
 import 'package:quacker/client/client_regular_account.dart';
 import 'package:quacker/client/client_unauthenticated.dart';
+import 'package:quacker/client/headers.dart';
 import 'package:quacker/generated/l10n.dart';
 import 'package:quacker/profile/profile_model.dart';
 import 'package:quacker/user.dart';
@@ -36,12 +37,11 @@ class _QuackerTwitterClient extends TwitterClient {
   }
 
   static Future<http.Response?> fetch(Uri uri, {Map<String, String>? headers}) async {
-    var prefs = await PrefServiceShared.init(prefix: 'pref_');
     final XRegularAccount model = XRegularAccount();
-    var authHeader = await model.getAuthHeader(prefs);
+    final authHeader = await TwitterHeaders.getAuthHeader();
 
     if (authHeader != null) {
-      return await model.fetch(uri, headers: headers, log: log, prefs: prefs, authHeader: authHeader);
+      return await model.fetch(uri, headers: headers, log: log, authHeader: authHeader);
     } else {
       return await fetchUnauthenticated(uri, headers: headers, log: log);
     }

--- a/lib/client/client_regular_account.dart
+++ b/lib/client/client_regular_account.dart
@@ -1,12 +1,8 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
-import 'package:pref/pref.dart';
+import 'package:quacker/client/headers.dart';
 import 'dart:async';
-import "dart:math";
-import 'package:quacker/constants.dart';
-import 'package:quacker/database/entities.dart';
 import 'package:quacker/database/repository.dart';
 
 class XRegularAccount extends ChangeNotifier {
@@ -17,42 +13,21 @@ class XRegularAccount extends ChangeNotifier {
   Future<http.Response?> fetch(Uri uri,
       {Map<String, String>? headers,
       required Logger log,
-      required BasePrefService prefs,
       required Map<dynamic, dynamic> authHeader}) async {
     log.info('Fetching $uri');
 
+    final baseHeaders = await TwitterHeaders.getHeaders(uri);
+
     var response = await http.get(uri, headers: {
       ...?headers,
-      ...authHeader,
-      ...userAgentHeader,
-      'authorization': bearerToken,
-      'x-twitter-active-user': 'yes',
-      'user-agent': userAgentHeader.toString()
+      ...baseHeaders
     });
 
     return response;
   }
 
-  Future<List<Map<String, Object?>>> getAccounts() async {
-    var database = await Repository.readOnly();
-    return database.query(tableAccounts);
-  }
-
   Future<void> deleteAccount(String username) async {
     var database = await Repository.writable();
     database.delete(tableAccounts, where: 'id = ?', whereArgs: [username]);
-  }
-
-  Future<Map<dynamic, dynamic>?> getAuthHeader(BasePrefService prefs) async {
-    final accounts = await getAccounts();
-
-    if (accounts.isNotEmpty) {
-      Account account = Account.fromMap(accounts[Random().nextInt(accounts.length)]);
-      final authHeader = Map.castFrom<String, dynamic, String, String>(json.decode(account.authHeader));
-
-      return authHeader;
-    } else {
-      return null;
-    }
   }
 }

--- a/lib/client/headers.dart
+++ b/lib/client/headers.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:pref/pref.dart';
+import 'dart:math';
+import 'package:quacker/database/entities.dart';
+import 'package:quacker/constants.dart';
+
+import 'accounts.dart';
+
+class TwitterHeaders {
+  static final Map<String, String> _baseHeaders = {
+    'accept': '*/*',
+    'accept-language': 'en-US,en;q=0.9',
+    'authorization': bearerToken,
+    'cache-control': 'no-cache',
+    'content-type': 'application/json',
+    'pragma': 'no-cache',
+    'priority': 'u=1, i',
+    'referer': 'https://x.com/',
+    'user-agent': userAgentHeader['user-agent']!,
+    'x-twitter-active-user': 'yes',
+    'x-twitter-client-language': 'en',
+  };
+
+  static Future<Map<String, String>?> getXClientTransactionIdHeader(Uri? uri) async {
+    if (uri == null) {
+      return null;
+    }
+
+    final path = uri.path;
+    final prefs = await PrefServiceShared.init(prefix: 'pref_');
+    final xClientTransactionIdDomain = prefs.get(optionXClientTransactionIdProvider) ?? optionXClientTransactionIdProviderDefaultDomain;
+    final xClientTransactionUriEndPoint = Uri.http(xClientTransactionIdDomain, '/generate-x-client-transaction-id', {'path': path});
+
+    try {
+      final response = await http.get(xClientTransactionUriEndPoint);
+
+      if (response.statusCode == 200) {
+        final xClientTransactionId = jsonDecode(response.body)['x-client-transaction-id'];
+        return {
+          'x-client-transaction-id': xClientTransactionId
+        };
+      } else {
+        throw Exception('Failed to get x-client-transaction-id. Status code: ${response.statusCode}');
+      }
+    } catch (e) {
+      throw Exception('Error getting x-client-transaction-id: $e');
+    }
+  }
+
+  static Future<Map<String, String>> getHeaders(Uri? uri) async {
+    final authHeader = await getAuthHeader();
+    final xClientTransactionIdHeader = await getXClientTransactionIdHeader(uri);
+    return {
+      ..._baseHeaders,
+      ...?authHeader,
+      ...?xClientTransactionIdHeader
+    };
+  }
+
+  static Future<Map<dynamic, dynamic>?> getAuthHeader() async {
+    final accounts = await getAccounts();
+    if(accounts.isEmpty) {
+      return null;
+    }
+    Account account = Account.fromMap(accounts[Random().nextInt(accounts.length)]);
+    final authHeader = Map.castFrom<String, dynamic, String, String>(json.decode(account.authHeader));
+    return authHeader;
+  }
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -52,6 +52,12 @@ const optionUserTrendsLocations = 'trends.locations';
 
 const optionNonConfirmationBiasMode = 'other.improve_non_confirmation_bias';
 
+// Default instance of https://github.com/Teskann/x-client-transaction-id-generator
+const String optionXClientTransactionIdProviderDefaultDomain = 'x-client-transaction-id-generator.xyz';
+
+const String optionXClientTransactionIdProvider = 'x_client_transaction_id_provider';
+
+
 final Map<String, String> userAgentHeader = {
   'user-agent':
       "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.3",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -430,5 +430,10 @@
   "foryou": "For You",
   "clickToShowMore": " \nClick to show more..",
   "show_navigation_labels": "Show navigation labels?",
-  "go_to_profile": "Go to profile: @"
+  "go_to_profile": "Go to profile: @",
+  "x_client_transaction_id_provider": "x-client-transaction-id provider",
+  "@x_client_transaction_id_provider": {},
+  "x_client_transaction_id_provider_description": "Set the x-client-transaction-id provider. It must he a domain name, without http/https prefix. For more information about it, check https://github.com/Teskann/x-client-transaction-id-generator",
+  "@x_client_transaction_id_provider_description": {}
+
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -490,5 +490,10 @@
   "functionality_unsupported": "Cette fonctionnalité n'est plus prise en charge par Twitter !",
   "@functionality_unsupported": {},
   "add_subscriptions": "Ajouter des abonnements",
-  "@add_subscriptions": {}
+  "@add_subscriptions": {},
+  "x_client_transaction_id_provider": "Fournisseur de x-client-transaction-id",
+  "@x_client_transaction_id_provider": {},
+  "x_client_transaction_id_provider_description": "Définir le fournisseur de x-client-transaction-id. Ce doit être un nom de domaine, sans préfixe http/https. Pour plus d'informations, consultez https://github.com/Teskann/x-client-transaction-id-generator",
+  "@x_client_transaction_id_provider_description": {}
+
 }

--- a/lib/settings/_account.dart
+++ b/lib/settings/_account.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:quacker/client/client_regular_account.dart';
 import 'package:quacker/client/login_webview.dart';
 import 'package:quacker/generated/l10n.dart';
+import 'package:quacker/client/accounts.dart';
 
 class SettingsAccountFragment extends StatefulWidget {
   const SettingsAccountFragment({super.key});
@@ -24,7 +25,7 @@ class _SettingsAccountFragment extends State<SettingsAccountFragment> {
         ],
       ),
       body: FutureBuilder(
-          future: model.getAccounts(),
+          future: getAccounts(),
           builder: (BuildContext listContext, AsyncSnapshot snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const LinearProgressIndicator();

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -83,6 +83,45 @@ class SettingsGeneralFragment extends StatelessWidget {
         ]);
   }
 
+  PrefDialog _createXClientTransactionIdDialog(BuildContext context, BasePrefService prefs) {
+    var mediaQuery = MediaQuery.of(context);
+    final controller = TextEditingController(
+        text: prefs.get(optionXClientTransactionIdProvider) ?? optionXClientTransactionIdProviderDefaultDomain
+    );
+
+    return PrefDialog(
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(L10n.of(context).cancel)
+          ),
+          TextButton(
+              onPressed: () async {
+                await prefs.set(optionXClientTransactionIdProvider,
+                    controller.text.isEmpty ? optionXClientTransactionIdProviderDefaultDomain : controller.text);
+                if (context.mounted) {
+                  Navigator.pop(context);
+                }
+              },
+              child: Text(L10n.of(context).save)
+          )
+        ],
+        title: Text(L10n.of(context).x_client_transaction_id_provider),
+        children: [
+          SizedBox(
+            width: mediaQuery.size.width,
+            child: TextFormField(
+              controller: controller,
+              decoration: InputDecoration(
+                  hintText: optionXClientTransactionIdProviderDefaultDomain
+              ),
+            ),
+          )
+        ]
+    );
+  }
+
+
   @override
   Widget build(BuildContext context) {
     var prefs = PrefService.of(context);
@@ -164,6 +203,11 @@ class SettingsGeneralFragment extends StatelessWidget {
             title: Text(L10n.of(context).activate_non_confirmation_bias_mode_label),
             pref: optionNonConfirmationBiasMode,
             subtitle: Text(L10n.of(context).activate_non_confirmation_bias_mode_description),
+          ),
+          PrefDialogButton(
+            title: Text(L10n.of(context).x_client_transaction_id_provider),
+            subtitle: Text(L10n.of(context).x_client_transaction_id_provider_description),
+            dialog: _createXClientTransactionIdDialog(context, prefs),
           ),
         ]),
       ),


### PR DESCRIPTION
Adressed #58

Issue was a missing header in the X graphql requests: `x-client-transaction-id`
This ID is supposed to be generated. As the generation is quite complex, I decided to rely on an existing working implementation: https://github.com/iSarabjitDhiman/XClientTransaction

This implementation is in Python but is very light weight. This is why I created a flask webserver that runs iSarabjitDhiman/XClientTransaction.

The project wrapping it to flask is available here: https://github.com/Teskann/x-client-transaction-id-generator

I created a public instance of this server on https://x-client-transaction-id-generator.xyz/

The idea in Quacker is to ask this server to generate an `x-client-transaction-id` for us. As this operation is very fast, I don't think it's an issue to contact another server.

I added an option to change the URL of the provider so that users can use any other working instance, maybe their own.

Regarding the code:
- I moved the headers management to a separate class
- I moved some functions from client_regular_account to accounts.dart / headers.dart
- I added the option to change the provider of `xclient-transaction-id` in General settings
- To manage the translation, I saw that the generated files are committed so I included them as well, because I didn't know if I should. I added a translation to french as it's my mother language.