### PR TITLE
Fixed #68 - Filtered ads from tweet replies

### DIFF
--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -236,6 +236,12 @@ class Twitter {
         users: response.users?.map((e) => UserWithExtra.fromJson(e.toJson())).toList() ?? []);
   }
 
+  static bool isNotPromoted(Map<String, dynamic> item) {
+    final bool entryIdContainsPromoted = item['entryId']?.contains("promoted") ?? false;
+    final bool hasPromotedMetadata = item['item']?['itemContent']?.containsKey("promotedMetadata") ?? false;
+    return !(entryIdContainsPromoted || hasPromotedMetadata);
+  }
+
   static List<TweetChain> createTweetChains(List<dynamic> addEntries) {
     List<TweetChain> replies = [];
 
@@ -265,7 +271,7 @@ class Twitter {
         List<TweetWithCard> tweets = [];
 
         // TODO: This is missing tombstone support
-        for (var item in entry['content']['items']) {
+        for (var item in entry['content']['items'].where((e) => isNotPromoted(e))) {
           var itemType = item['item']?['itemContent']?['itemType'];
           if (itemType == 'TimelineTweet') {
             if (item['item']['itemContent']['tweet_results']?['result'] != null) {


### PR DESCRIPTION
Fixed #68

Typical response from a sponsored tweet:

<img width="1018" height="645" alt="image" src="https://github.com/user-attachments/assets/005d111f-50aa-4e0c-88e0-06b168874532" />

There don't exist in normal tweets:

<img width="987" height="611" alt="image" src="https://github.com/user-attachments/assets/0bb11f4b-a510-4272-89a9-e7bff7b7d8a5" />

If I can find any of the two highlighted values, the tweet is filtered